### PR TITLE
Add translation module

### DIFF
--- a/src/FormContext.js
+++ b/src/FormContext.js
@@ -4,9 +4,7 @@ import InputSchema, { unwrapNonNull } from "./InputSchema";
 import { action, isObservableObject, makeObservable, observable } from "mobx";
 import get from "lodash.get";
 import FieldMode from "./FieldMode";
-import TranslationHelper from "./util/TranslationHelper";
-
-const {i18n} = TranslationHelper;
+import { i18n } from "./util/TranslationHelper";
 
 let defaultFormContext;
 

--- a/src/FormContext.js
+++ b/src/FormContext.js
@@ -4,7 +4,9 @@ import InputSchema, { unwrapNonNull } from "./InputSchema";
 import { action, isObservableObject, makeObservable, observable } from "mobx";
 import get from "lodash.get";
 import FieldMode from "./FieldMode";
+import TranslationHelper from "./util/TranslationHelper";
 
+const {i18n} = TranslationHelper;
 
 let defaultFormContext;
 
@@ -609,7 +611,7 @@ export default class FormContext
                 {
                     if (typeof converted !== "boolean" && typeof converted !== "string")
                     {
-                        scalarResult = "Invalid Value"
+                        scalarResult = i18n("Invalid Value")
                     }
                     else
                     {
@@ -655,7 +657,7 @@ export default class FormContext
                     {
                         console.warn("Invalid value for Enum " + enumTypeName + " at " + path + " in " + JSON.stringify(root) + ": " + value);
                     }
-                    this.addError(root, path, "Invalid Enum Value" , value);
+                    this.addError(root, path, i18n("Invalid Enum Value") , value);
                 }
             }
         }
@@ -711,7 +713,7 @@ export default class FormContext
             parentType = fieldName;
         }
 
-        return parentType + ":Field Required";
+        return i18n(parentType + ":Field Required");
     }
 
 

--- a/src/default-converters.js
+++ b/src/default-converters.js
@@ -1,8 +1,6 @@
 import BigNumber from "bignumber.js"
 import parseNumber, { clean } from "./util/parse-number"
-import TranslationHelper from "./util/TranslationHelper";
-
-const {i18n} = TranslationHelper;
+import { i18n } from "./util/TranslationHelper";
 
 const BOOLEAN_RE = /^true|false|on|off$/;
 

--- a/src/default-converters.js
+++ b/src/default-converters.js
@@ -1,5 +1,8 @@
 import BigNumber from "bignumber.js"
 import parseNumber, { clean } from "./util/parse-number"
+import TranslationHelper from "./util/TranslationHelper";
+
+const {i18n} = TranslationHelper;
 
 const BOOLEAN_RE = /^true|false|on|off$/;
 
@@ -13,7 +16,7 @@ function checkInteger(lower, upper, msg)
         const num = +value;
         if (isNaN(num) || value === "" || !INTEGER_RE.test(value) || num < lower || num > upper)
         {
-            return msg;
+            return i18n(msg);
         }
         return null;
     }
@@ -25,7 +28,7 @@ function checkNumber(msg)
         const num = +value;
         if (isNaN(num))
         {
-            return msg;
+            return i18n(msg);
         }
         return null;
     }
@@ -36,7 +39,7 @@ function checkRegexp(re, msg)
     return function (value) {
         if (!re.test(value))
         {
-            return msg;
+            return i18n(msg);
         }
         return null;
     };
@@ -54,7 +57,7 @@ const DEFAULT_CONVERTERS = {
 
             if (ctx && ctx.maxLength && v.length > ctx.maxLength)
             {
-                return "Value too long";
+                return i18n("Value too long");
             }
             return null;
         },
@@ -62,7 +65,7 @@ const DEFAULT_CONVERTERS = {
         valueToScalar: false
     },
     "Boolean" : {
-        validate: v => typeof v !== "boolean" ? "Invalid boolean" : null,
+        validate: v => typeof v !== "boolean" ? i18n("Invalid boolean") : null,
         scalarToValue: function (scalar) {
             return scalar;
         },
@@ -97,7 +100,7 @@ const DEFAULT_CONVERTERS = {
             }
             if (isNaN(num) || num < CURRENCY_LIMIT_LOW || num > CURRENCY_LIMIT_HIGH)
             {
-                return "Invalid currency value";
+                return i18n("Invalid currency value");
             }
             return null;
         },
@@ -161,7 +164,7 @@ const DEFAULT_CONVERTERS = {
         }
     },
     "Date" : {
-        validate: checkRegexp(DATE_RE),
+        validate: checkRegexp(DATE_RE, "Invalid Date"),
 
         scalarToValue: function (scalar) {
             return String(scalar)
@@ -171,7 +174,7 @@ const DEFAULT_CONVERTERS = {
         }
     },
     "Timestamp" : {
-        validate: checkRegexp(DATE_RE),
+        validate: checkRegexp(DATE_RE, "Invalid Timestamp"),
 
         scalarToValue: function (scalar) {
             return String(scalar)

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ import Addon from "./Addon";
 import { renderStaticField } from "./default-renderers"
 import { clone, cloneList, fallbackJSClone, registerDomainObjectFactory, registerFallbackCloneFunction } from "./util/clone";
 import FormContext from "./FormContext";
-import TranslationHelper from "./util/TranslationHelper";
+import { registerI18n } from "./util/TranslationHelper";
 
 // noinspection JSUnusedGlobalSymbols
 export {
@@ -70,5 +70,5 @@ export {
 
     FormContext,
 
-    TranslationHelper
+    registerI18n
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ import Addon from "./Addon";
 import { renderStaticField } from "./default-renderers"
 import { clone, cloneList, fallbackJSClone, registerDomainObjectFactory, registerFallbackCloneFunction } from "./util/clone";
 import FormContext from "./FormContext";
+import TranslationHelper from "./util/TranslationHelper";
 
 // noinspection JSUnusedGlobalSymbols
 export {
@@ -67,5 +68,7 @@ export {
     renderStaticField,
     resolveStaticRenderer,
 
-    FormContext
+    FormContext,
+
+    TranslationHelper
 }

--- a/src/util/TranslationHelper.js
+++ b/src/util/TranslationHelper.js
@@ -1,5 +1,13 @@
 let i18nFn = a => a;
 
+/**
+ * Register a custom i18n translation function for domainql-form
+ * 
+ * The function registered by default will return the key as is without altering or translating.
+ * If a value that is not a function is passed as translator, the default function will be used.
+ * 
+ * @param {i18n} translator - the translation function to be registered
+ */
 export function registerI18n(translator) {
     if (typeof translator === "function") {
         i18nFn = translator;
@@ -8,6 +16,13 @@ export function registerI18n(translator) {
     }
 }
 
+/**
+ * Returns a translation of the given translation key with additional optional arguments
+ *
+ * @param {string} key - translation tag/key
+ * @param {...string} args - optional translation parameters
+ * @returns {string}
+ */
 export function i18n(key, ...args) {
     return i18nFn(key, args);
 }

--- a/src/util/TranslationHelper.js
+++ b/src/util/TranslationHelper.js
@@ -1,0 +1,19 @@
+let i18nFn = a => a;
+
+const TranslationHelper = {
+
+    registerI18n: function(translator) {
+        if (typeof translator === "function") {
+            i18nFn = translator;
+        } else {
+            i18nFn = a => a;
+        }
+    },
+
+    i18n: function(key, ...args) {
+        return i18nFn(key, args);
+    }
+
+}
+
+export default TranslationHelper;

--- a/src/util/TranslationHelper.js
+++ b/src/util/TranslationHelper.js
@@ -1,19 +1,13 @@
 let i18nFn = a => a;
 
-const TranslationHelper = {
-
-    registerI18n: function(translator) {
-        if (typeof translator === "function") {
-            i18nFn = translator;
-        } else {
-            i18nFn = a => a;
-        }
-    },
-
-    i18n: function(key, ...args) {
-        return i18nFn(key, args);
+export function registerI18n(translator) {
+    if (typeof translator === "function") {
+        i18nFn = translator;
+    } else {
+        i18nFn = a => a;
     }
-
 }
 
-export default TranslationHelper;
+export function i18n(key, ...args) {
+    return i18nFn(key, args);
+}


### PR DESCRIPTION
Add a translation module that allows registering a function to handle
i18n calls in domainql-form, since it generates AND renders its own
errors which should be translated if needed.
If no translation module is registered, the input argument gets
returned.