### PR TITLE
Add onChange to FormConfig options parameter

### DIFF
--- a/src/FormConfig.js
+++ b/src/FormConfig.js
@@ -309,6 +309,7 @@ class FormConfig
         //console.log("updateFromChange", path, converted, errorsForField)
 
         const { root, formContext } = this;
+        const { onChange } = this.options;
         const { path, qualifiedName } = fieldContext;
 
         formContext.updateErrors(root, qualifiedName, errorsForField);
@@ -316,6 +317,10 @@ class FormConfig
         if (errorsForField.length < 2)
         {
             set(root, path, converted);
+
+            if (typeof onChange === "function") {
+                onChange(root, path, converted);
+            }
 
             if (this.options.autoSubmit)
             {


### PR DESCRIPTION
To easily get notified by changes to the form data, a change handler is
added to the options parameter of the FormConfig and respectively to
the Form component