### PR TITLE
Store the ID of the domain object in form

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -219,6 +219,7 @@ const Form  = props =>  {
             onReset={ handleReset }
             onClick={ onClick || null }
             data-form-id={ formId }
+            data-domain-id={ value?.id }
             { ... rest }
         >
             <FormConfigContext.Provider value={ formConfig }>


### PR DESCRIPTION
Since it will be neccessary for certain elements (like shortcut items) to know what domain object a form belongs to, the domain object ID will now be additionally stored inside the dataset of the form.