### PR TITLE
Fix form not updating root on value change.

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -105,6 +105,14 @@ const Form  = props =>  {
 
     useEffect(
         () => {
+            const root = cloneRoot(schema, value, options, parentConfig);
+            setRoot(root);
+        },
+        [schema, value, options, parentConfig]
+    )
+
+    useEffect(
+        () => {
             return () => formContext.unregisterForm(formId)
         },
         []


### PR DESCRIPTION
If the value changed, the old root still was the same desyncing the form from the external data source.
Actually renew the root if the value (or schema, options, parentConfig) changes.